### PR TITLE
Add DB persistence for activities and participants

### DIFF
--- a/database_setup.py
+++ b/database_setup.py
@@ -1,0 +1,109 @@
+"""Create database schema and seed initial activities.
+
+Run once to create `activities.db` (or the DB configured by DATABASE_URL).
+"""
+from src.database import engine
+from src.models import Base, Activity, Participant
+
+
+def seed_initial_data(session):
+    # Initial activities copied from the original in-memory store
+    initial = [
+        {
+            "name": "Chess Club",
+            "description": "Learn strategies and compete in chess tournaments",
+            "schedule": "Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 12,
+            "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
+        },
+        {
+            "name": "Programming Class",
+            "description": "Learn programming fundamentals and build software projects",
+            "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+            "max_participants": 20,
+            "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
+        },
+        {
+            "name": "Gym Class",
+            "description": "Physical education and sports activities",
+            "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+            "max_participants": 30,
+            "participants": ["john@mergington.edu", "olivia@mergington.edu"],
+        },
+        {
+            "name": "Soccer Team",
+            "description": "Join the school soccer team and compete in matches",
+            "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+            "max_participants": 22,
+            "participants": ["liam@mergington.edu", "noah@mergington.edu"],
+        },
+        {
+            "name": "Basketball Team",
+            "description": "Practice and play basketball with the school team",
+            "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 15,
+            "participants": ["ava@mergington.edu", "mia@mergington.edu"],
+        },
+        {
+            "name": "Art Club",
+            "description": "Explore your creativity through painting and drawing",
+            "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+            "max_participants": 15,
+            "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
+        },
+        {
+            "name": "Drama Club",
+            "description": "Act, direct, and produce plays and performances",
+            "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+            "max_participants": 20,
+            "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
+        },
+        {
+            "name": "Math Club",
+            "description": "Solve challenging problems and participate in math competitions",
+            "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+            "max_participants": 10,
+            "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
+        },
+        {
+            "name": "Debate Team",
+            "description": "Develop public speaking and argumentation skills",
+            "schedule": "Fridays, 4:00 PM - 5:30 PM",
+            "max_participants": 12,
+            "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+        },
+    ]
+
+    for act in initial:
+        existing = session.query(Activity).filter(Activity.name == act["name"]).first()
+        if existing:
+            continue
+        a = Activity(
+            name=act["name"],
+            description=act["description"],
+            schedule=act["schedule"],
+            max_participants=act["max_participants"],
+        )
+        session.add(a)
+        session.flush()
+        for email in act["participants"]:
+            p = Participant(activity_id=a.id, email=email)
+            session.add(p)
+    session.commit()
+
+
+def main():
+    # Create tables
+    Base.metadata.create_all(bind=engine)
+
+    # Seed data
+    from sqlalchemy.orm import sessionmaker
+
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    seed_initial_data(session)
+    session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+sqlalchemy

--- a/src/app.py
+++ b/src/app.py
@@ -1,15 +1,21 @@
 """
 High School Management System API
 
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
+FastAPI application that allows students to view and sign up
+for extracurricular activities at Mergington High School. Activities
+are now persisted to a SQLite database using SQLAlchemy.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+from sqlalchemy.orm import Session
+
+from src.database import get_db
+from src.models import Activity, Participant
+
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,64 +25,6 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
-
 
 @app.get("/")
 def root():
@@ -84,49 +32,54 @@ def root():
 
 
 @app.get("/activities")
-def get_activities():
-    return activities
+def get_activities(db: Session = Depends(get_db)):
+    results = {}
+    activities = db.query(Activity).all()
+    for a in activities:
+        results[a.name] = {
+            "description": a.description,
+            "schedule": a.schedule,
+            "max_participants": a.max_participants,
+            "participants": [p.email for p in a.participants],
+        }
+    return results
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, db: Session = Depends(get_db)):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    activity = db.query(Activity).filter(Activity.name == activity_name).first()
+    if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+    # Check duplicate
+    exists = db.query(Participant).filter(Participant.activity_id == activity.id, Participant.email == email).first()
+    if exists:
+        raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+    # Enforce max participants if set
+    if activity.max_participants is not None:
+        count = db.query(Participant).filter(Participant.activity_id == activity.id).count()
+        if count >= activity.max_participants:
+            raise HTTPException(status_code=400, detail="Activity is full")
 
-    # Add student
-    activity["participants"].append(email)
+    participant = Participant(activity_id=activity.id, email=email)
+    db.add(participant)
+    db.commit()
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, db: Session = Depends(get_db)):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    activity = db.query(Activity).filter(Activity.name == activity_name).first()
+    if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+    participant = db.query(Participant).filter(Participant.activity_id == activity.id, Participant.email == email).first()
+    if not participant:
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
+    db.delete(participant)
+    db.commit()
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,19 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./activities.db")
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {},
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,29 @@
+from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey
+from sqlalchemy.orm import relationship, declarative_base
+from datetime import datetime
+
+Base = declarative_base()
+
+
+class Activity(Base):
+    __tablename__ = "activities"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(200), unique=True, nullable=False)
+    description = Column(Text, nullable=True)
+    schedule = Column(String(200), nullable=True)
+    max_participants = Column(Integer, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    participants = relationship("Participant", back_populates="activity", cascade="all, delete-orphan")
+
+
+class Participant(Base):
+    __tablename__ = "participants"
+
+    id = Column(Integer, primary_key=True, index=True)
+    activity_id = Column(Integer, ForeignKey("activities.id", ondelete="CASCADE"), nullable=False)
+    email = Column(String(255), nullable=False, index=True)
+    joined_at = Column(DateTime, default=datetime.utcnow)
+
+    activity = relationship("Activity", back_populates="participants")


### PR DESCRIPTION
This PR adds SQLAlchemy models for activities and participants, a DB helper, a `database_setup.py` script to create and seed the DB, and updates `src/app.py` to use the database for listing/signups/unregistering. It also adds `sqlalchemy` to `requirements.txt`.

Notes:
- Run `python database_setup.py` (or set DATABASE_URL and run) to create and seed the DB.
- This is an initial migration to SQLite. We can switch to Postgres by setting `DATABASE_URL` later.